### PR TITLE
Add desktop bot that drives TETR.IO via Zetris AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,56 @@
-# Tetrio-bot
+# TETR.IO Bot
+
+Ce projet fournit une interface graphique qui s'accroche automatiquement à la fenêtre TETR.IO active et délègue les coups à l'IA [Zetris](https://github.com/ZetrisAI/Zetris).
+
+## Installation
+
+1. Créez un environnement virtuel Python 3.10 ou plus récent.
+2. Installez les dépendances :
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Installez ensuite l'IA Zetris (l'archive officielle est nécessaire) :
+
+   ```bash
+   pip install git+https://github.com/ZetrisAI/Zetris
+   ```
+
+> ⚠️ Si votre réseau bloque l'accès direct à GitHub, clonez le dépôt Zetris manuellement et installez-le en local (`pip install .`).
+
+## Calibration
+
+Avant la première utilisation, effectuez la calibration pour apprendre au bot où se trouvent la matrice de jeu et l'aperçu des prochaines pièces :
+
+1. Lancez TETR.IO et assurez-vous que la fenêtre est bien visible.
+2. Exécutez le lanceur du bot :
+
+   ```bash
+   python scripts/run_bot.py
+   ```
+3. Dans l'interface, cliquez sur **🧭 Calibration**.
+4. Suivez les instructions : positionnez le curseur sur les coins du plateau et de l'aperçu puis appuyez sur `F8` à chaque étape.
+5. La configuration est enregistrée dans `~/.config/tetrio-bot/config.json`.
+
+## Utilisation
+
+1. Assurez-vous que TETR.IO est lancé et que la partie est prête à commencer (mode solo recommandé).
+2. Ouvrez l'interface (`python scripts/run_bot.py`).
+3. Cliquez sur **▶️ Lancer**. Le bot active automatiquement la fenêtre TETR.IO, capture l'écran, reconstruit la grille puis demande à Zetris le meilleur coup à jouer.
+4. Cliquez sur **⏹️ Arrêter** pour reprendre la main.
+
+## Personnalisation
+
+- Le fichier de configuration permet d'ajuster les touches envoyées (`keymap`) ainsi que la cadence (`tick_rate`).
+- Les touches par défaut correspondent au schéma TETR.IO standard (flèches, espace pour hard drop, `Z`/`Up` pour les rotations, `C` pour le hold).
+
+## Dépannage
+
+- Si un message indique que `load_policy` ou `plan` est introuvable, vérifiez la version de Zetris installée.
+- Les captures d'écran reposent sur l'API `mss`. Sur macOS, pensez à autoriser l'accès à l'enregistrement d'écran pour votre terminal Python.
+- Sur Linux, l'envoi de touches nécessite généralement d'exécuter le script avec les permissions d'accès au serveur d'affichage (`xhost +` dans certains cas).
+- Sur Windows, `pygetwindow` nécessite l'installation des dépendances `pywin32` qui sont installées automatiquement par `pip`.
+
+## Licence
+
+Ce projet est fourni tel quel, sans garantie. Respectez les conditions d'utilisation de TETR.IO et de Zetris lorsque vous utilisez ce bot.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+mss
+numpy
+Pillow
+pyautogui
+pygetwindow
+pynput
+
+# Tkinter is bundled with Python on most platforms, but on some Linux
+# distributions you might have to install the `python3-tk` package.

--- a/scripts/run_bot.py
+++ b/scripts/run_bot.py
@@ -1,0 +1,19 @@
+"""Entry point to start the GUI bot."""
+from __future__ import annotations
+
+import argparse
+
+from tetrio_bot.gui import BotGUI
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="TETR.IO auto-player powered by Zetris")
+    parser.add_argument("--policy", help="Chemin vers le modèle Zetris (optionnel)", default=None)
+    args = parser.parse_args()
+
+    gui = BotGUI(policy_path=args.policy)
+    gui.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tetrio_bot/__init__.py
+++ b/tetrio_bot/__init__.py
@@ -1,0 +1,5 @@
+"""High-level package exports for the TETR.IO bot."""
+from .gui import BotGUI
+from .runner import BotRunner
+
+__all__ = ["BotGUI", "BotRunner"]

--- a/tetrio_bot/calibration.py
+++ b/tetrio_bot/calibration.py
@@ -1,0 +1,101 @@
+"""Utilities to calibrate the capture regions."""
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import pyautogui
+from pynput import keyboard
+
+from .config import Region, Settings, save_settings
+
+pyautogui.FAILSAFE = False
+
+
+@dataclass
+class CalibrationResult:
+    board_region: Region
+    preview_region: Region
+
+
+class _HotkeyWaiter:
+    def __init__(self, target_key: keyboard.Key | keyboard.KeyCode):
+        self._target_key = target_key
+        self._event = threading.Event()
+
+    def __enter__(self) -> "_HotkeyWaiter":
+        self._listener = keyboard.Listener(on_press=self._on_press)
+        self._listener.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self._listener.stop()
+
+    def _on_press(self, key) -> None:
+        if key == self._target_key:
+            self._event.set()
+
+    def wait(self, timeout: Optional[float] = None) -> bool:
+        return self._event.wait(timeout)
+
+
+def _capture_point(prompt: str, *, target_key: keyboard.Key, on_update: Optional[Callable[[tuple[int, int]], None]] = None) -> tuple[int, int]:
+    print(prompt)
+    with _HotkeyWaiter(target_key) as waiter:
+        while not waiter.wait(0.05):
+            position = pyautogui.position()
+            if on_update:
+                on_update((position.x, position.y))
+            time.sleep(0.05)
+    pos = pyautogui.position()
+    print(f"Position enregistrée: {pos.x}, {pos.y}")
+    return pos.x, pos.y
+
+
+def calibrate(settings: Settings, *, status_callback: Optional[Callable[[str], None]] = None) -> CalibrationResult:
+    """Interactively calibrate the capture regions.
+
+    The user is asked to place their mouse on the top-left and bottom-right corners
+    of the TETR.IO matrix as well as the preview box. They must press F8 to record
+    each point.
+    """
+
+    def notify(message: str) -> None:
+        print(message)
+        if status_callback:
+            status_callback(message)
+
+    notify("Placez le curseur sur la CASE en haut à gauche du plateau puis appuyez sur F8.")
+    top_left_x, top_left_y = _capture_point("-> En attente du point haut gauche (F8)", target_key=keyboard.Key.f8)
+
+    notify("Placez le curseur sur la CASE en bas à droite du plateau puis appuyez sur F8.")
+    bottom_right_x, bottom_right_y = _capture_point("-> En attente du point bas droite (F8)", target_key=keyboard.Key.f8)
+
+    board_region = Region(
+        left=min(top_left_x, bottom_right_x),
+        top=min(top_left_y, bottom_right_y),
+        width=abs(bottom_right_x - top_left_x),
+        height=abs(bottom_right_y - top_left_y),
+    )
+
+    notify("Placez le curseur sur l'aperçu des prochaines pièces (haut gauche) et appuyez sur F8.")
+    preview_top_left_x, preview_top_left_y = _capture_point("-> En attente du point haut gauche de l'aperçu (F8)", target_key=keyboard.Key.f8)
+
+    notify("Placez le curseur sur le coin bas droite de l'aperçu et appuyez sur F8.")
+    preview_bottom_right_x, preview_bottom_right_y = _capture_point("-> En attente du point bas droite de l'aperçu (F8)", target_key=keyboard.Key.f8)
+
+    preview_region = Region(
+        left=min(preview_top_left_x, preview_bottom_right_x),
+        top=min(preview_top_left_y, preview_bottom_right_y),
+        width=abs(preview_bottom_right_x - preview_top_left_x),
+        height=abs(preview_bottom_right_y - preview_top_left_y),
+    )
+
+    settings.board_region = board_region
+    settings.preview_region = preview_region
+    save_settings(settings)
+
+    notify("Calibration terminée et enregistrée.")
+    return CalibrationResult(board_region=board_region, preview_region=preview_region)

--- a/tetrio_bot/capture.py
+++ b/tetrio_bot/capture.py
@@ -1,0 +1,135 @@
+"""Screen capture and board extraction utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import numpy as np
+from mss import mss
+
+from .config import Region
+
+
+@dataclass
+class BoardState:
+    grid: np.ndarray  # shape (20, 10), 0 empty, 1 filled
+
+
+class BoardCapture:
+    """Capture the TETR.IO board and extract grid occupancy."""
+
+    def __init__(self, board_region: Region):
+        if board_region.width <= 0 or board_region.height <= 0:
+            raise ValueError("Board region is not configured. Run the calibration first.")
+        self._region = board_region
+        self._sct = mss()
+
+    def _grab_frame(self) -> np.ndarray:
+        bbox = {
+            "left": self._region.left,
+            "top": self._region.top,
+            "width": self._region.width,
+            "height": self._region.height,
+        }
+        raw = self._sct.grab(bbox)
+        frame = np.array(raw)
+        return frame[:, :, :3]
+
+    def capture_board(self) -> BoardState:
+        frame = self._grab_frame()
+        grid = self._grid_from_frame(frame)
+        return BoardState(grid=grid)
+
+    def _grid_from_frame(self, frame: np.ndarray) -> np.ndarray:
+        height, width, _ = frame.shape
+        cell_height = height / 20
+        cell_width = width / 10
+
+        grid = np.zeros((20, 10), dtype=np.uint8)
+
+        for row in range(20):
+            for col in range(10):
+                center_y = int((row + 0.5) * cell_height)
+                center_x = int((col + 0.5) * cell_width)
+                center_y = min(center_y, height - 1)
+                center_x = min(center_x, width - 1)
+                pixel = frame[center_y, center_x]
+                occupied = self._is_occupied(pixel)
+                grid[row, col] = 1 if occupied else 0
+
+        return grid
+
+    @staticmethod
+    def _is_occupied(pixel: np.ndarray) -> bool:
+        # TETR.IO empty cells are very dark, so we can threshold the brightness.
+        brightness = pixel.mean() / 255.0
+        return brightness > 0.12
+
+
+class PreviewCapture:
+    """Capture the preview region and infer the next piece queue.
+
+    The detection logic is intentionally simple and expects the preview area to
+    contain square thumbnails on a dark background. We quantise the dominant
+    colour of each thumbnail to map it back to piece identifiers.
+    """
+
+    _PIECE_COLOURS = {
+        "I": np.array([0, 240, 240]),
+        "J": np.array([0, 0, 240]),
+        "L": np.array([240, 160, 0]),
+        "O": np.array([240, 240, 0]),
+        "S": np.array([0, 240, 0]),
+        "T": np.array([160, 0, 240]),
+        "Z": np.array([240, 0, 0]),
+    }
+
+    def __init__(self, preview_region: Region):
+        if preview_region.width <= 0 or preview_region.height <= 0:
+            raise ValueError("Preview region is not configured. Run the calibration first.")
+        self._region = preview_region
+        self._sct = mss()
+
+    def capture_queue(self, *, max_pieces: int = 5) -> List[str]:
+        frame = self._grab_frame()
+        return self._pieces_from_frame(frame, max_pieces=max_pieces)
+
+    def _grab_frame(self) -> np.ndarray:
+        bbox = {
+            "left": self._region.left,
+            "top": self._region.top,
+            "width": self._region.width,
+            "height": self._region.height,
+        }
+        raw = self._sct.grab(bbox)
+        return np.array(raw)[:, :, :3]
+
+    def _pieces_from_frame(self, frame: np.ndarray, *, max_pieces: int) -> List[str]:
+        height, width, _ = frame.shape
+        slot_height = height / max_pieces
+        slot_width = width
+        pieces: List[str] = []
+
+        for index in range(max_pieces):
+            y0 = int(index * slot_height)
+            y1 = int((index + 1) * slot_height)
+            x0 = 0
+            x1 = int(slot_width)
+            tile = frame[y0:y1, x0:x1]
+            if tile.size == 0:
+                continue
+            dominant_colour = tile.reshape(-1, 3).mean(axis=0)
+            piece = self._closest_piece(dominant_colour)
+            pieces.append(piece)
+
+        return pieces
+
+    def _closest_piece(self, colour: np.ndarray) -> str:
+        best_piece = "I"
+        best_distance = float("inf")
+        for piece, ref_colour in self._PIECE_COLOURS.items():
+            distance = np.linalg.norm(colour - ref_colour)
+            if distance < best_distance:
+                best_piece = piece
+                best_distance = distance
+        return best_piece

--- a/tetrio_bot/config.py
+++ b/tetrio_bot/config.py
@@ -1,0 +1,96 @@
+"""Configuration management for the TETR.IO bot."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict
+
+CONFIG_DIR = Path.home() / ".config" / "tetrio-bot"
+DEFAULT_CONFIG_PATH = CONFIG_DIR / "config.json"
+
+
+def _default_keymap() -> Dict[str, str]:
+    return {
+        "move_left": "Left",
+        "move_right": "Right",
+        "soft_drop": "Down",
+        "hard_drop": "space",
+        "rotate_cw": "Up",
+        "rotate_ccw": "z",
+        "rotate_180": "a",
+        "hold": "c",
+    }
+
+
+@dataclass
+class Region:
+    left: int = 0
+    top: int = 0
+    width: int = 0
+    height: int = 0
+
+    @property
+    def right(self) -> int:
+        return self.left + self.width
+
+    @property
+    def bottom(self) -> int:
+        return self.top + self.height
+
+    def to_dict(self) -> Dict[str, int]:
+        return {
+            "left": self.left,
+            "top": self.top,
+            "width": self.width,
+            "height": self.height,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, int]) -> "Region":
+        return cls(
+            left=int(data.get("left", 0)),
+            top=int(data.get("top", 0)),
+            width=int(data.get("width", 0)),
+            height=int(data.get("height", 0)),
+        )
+
+
+@dataclass
+class Settings:
+    board_region: Region = field(default_factory=Region)
+    preview_region: Region = field(default_factory=Region)
+    tick_rate: float = 0.12
+    keymap: Dict[str, str] = field(default_factory=_default_keymap)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "board_region": self.board_region.to_dict(),
+            "preview_region": self.preview_region.to_dict(),
+            "tick_rate": self.tick_rate,
+            "keymap": self.keymap,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "Settings":
+        return cls(
+            board_region=Region.from_dict(data.get("board_region", {})),
+            preview_region=Region.from_dict(data.get("preview_region", {})),
+            tick_rate=float(data.get("tick_rate", 0.12)),
+            keymap=dict(data.get("keymap", _default_keymap())),
+        )
+
+
+def load_settings(path: Path = DEFAULT_CONFIG_PATH) -> Settings:
+    if not path.exists():
+        return Settings()
+
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    return Settings.from_dict(data)
+
+
+def save_settings(settings: Settings, path: Path = DEFAULT_CONFIG_PATH) -> None:
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(settings.to_dict(), handle, indent=2)

--- a/tetrio_bot/controller.py
+++ b/tetrio_bot/controller.py
@@ -1,0 +1,41 @@
+"""Keyboard controller for sending moves to the TETR.IO window."""
+from __future__ import annotations
+
+import time
+from typing import Iterable, Mapping
+
+from pynput.keyboard import Controller, Key
+
+
+class InputController:
+    def __init__(self, keymap: Mapping[str, str]):
+        self._controller = Controller()
+        self._keymap = {action: self._normalise_key(key) for action, key in keymap.items()}
+
+    @staticmethod
+    def _normalise_key(key: str):
+        if len(key) == 1:
+            return key.lower()
+        special = {
+            "left": Key.left,
+            "right": Key.right,
+            "up": Key.up,
+            "down": Key.down,
+            "space": Key.space,
+            "shift": Key.shift,
+            "ctrl": Key.ctrl,
+        }
+        return special.get(key.lower(), key)
+
+    def tap(self, key):
+        self._controller.press(key)
+        time.sleep(0.01)
+        self._controller.release(key)
+
+    def execute_actions(self, actions: Iterable[str]) -> None:
+        for action in actions:
+            key = self._keymap.get(action)
+            if not key:
+                continue
+            self.tap(key)
+            time.sleep(0.01)

--- a/tetrio_bot/gui.py
+++ b/tetrio_bot/gui.py
@@ -1,0 +1,73 @@
+"""Tkinter interface for controlling the bot."""
+from __future__ import annotations
+
+import threading
+import tkinter as tk
+from tkinter import messagebox
+
+from .calibration import calibrate
+from .config import Settings, load_settings, save_settings
+from .runner import BotRunner
+
+
+class BotGUI:
+    def __init__(self, *, policy_path: str | None = None):
+        self._settings = load_settings()
+        self._policy_path = policy_path
+        self._runner = BotRunner(self._settings, policy_path=policy_path)
+        self._running = False
+
+        self._root = tk.Tk()
+        self._root.title("TETR.IO Bot")
+        self._root.geometry("360x220")
+
+        self._status_var = tk.StringVar(value="Bot arrêté.")
+
+        self._start_button = tk.Button(self._root, text="▶️ Lancer", command=self._toggle_start)
+        self._start_button.pack(pady=12)
+
+        self._calibrate_button = tk.Button(self._root, text="🧭 Calibration", command=self._launch_calibration)
+        self._calibrate_button.pack(pady=12)
+
+        self._status_label = tk.Label(self._root, textvariable=self._status_var, wraplength=320)
+        self._status_label.pack(pady=12)
+
+        self._root.protocol("WM_DELETE_WINDOW", self._on_close)
+
+    def run(self) -> None:
+        self._root.mainloop()
+
+    def _toggle_start(self) -> None:
+        if not self._running:
+            try:
+                self._runner.start()
+            except ValueError as exc:
+                messagebox.showerror("Configuration manquante", str(exc))
+                return
+            except RuntimeError as exc:
+                messagebox.showerror("Erreur", str(exc))
+                return
+            self._running = True
+            self._status_var.set("Bot en cours d'exécution.")
+            self._start_button.configure(text="⏹️ Arrêter")
+        else:
+            self._runner.stop()
+            self._running = False
+            self._status_var.set("Bot arrêté.")
+            self._start_button.configure(text="▶️ Lancer")
+
+    def _launch_calibration(self) -> None:
+        def task() -> None:
+            try:
+                calibrate(self._settings, status_callback=self._status_var.set)
+                save_settings(self._settings)
+                self._runner = BotRunner(self._settings, policy_path=self._policy_path)
+            except Exception as exc:  # pragma: no cover - manual workflow
+                messagebox.showerror("Erreur", str(exc))
+
+        threading.Thread(target=task, daemon=True).start()
+
+    def _on_close(self) -> None:
+        if self._running:
+            self._runner.stop()
+        self._root.destroy()

--- a/tetrio_bot/runner.py
+++ b/tetrio_bot/runner.py
@@ -1,0 +1,50 @@
+"""Bot runtime loop."""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Optional
+
+import numpy as np
+
+from .capture import BoardCapture, PreviewCapture
+from .config import Settings
+from .controller import InputController
+from .window import focus_tetrio_window
+from .zetris_wrapper import ZetrisAdapter
+
+
+class BotRunner:
+    def __init__(self, settings: Settings, *, policy_path: str | None = None):
+        self._settings = settings
+        self._policy_path = policy_path
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._thread and self._thread.is_alive():
+            self._stop_event.set()
+            self._thread.join()
+
+    def _run_loop(self) -> None:
+        if not focus_tetrio_window():
+            raise RuntimeError("Impossible de trouver une fenêtre TETR.IO active.")
+
+        board_capture = BoardCapture(self._settings.board_region)
+        preview_capture = PreviewCapture(self._settings.preview_region)
+        controller = InputController(self._settings.keymap)
+        zetris = ZetrisAdapter(policy_path=self._policy_path)
+
+        while not self._stop_event.is_set():
+            board_state = board_capture.capture_board()
+            queue = preview_capture.capture_queue(max_pieces=5)
+            decision = zetris.decide(board_state.grid.astype(np.float32), queue, hold=None)
+            controller.execute_actions(decision.actions)
+            time.sleep(self._settings.tick_rate)

--- a/tetrio_bot/window.py
+++ b/tetrio_bot/window.py
@@ -1,0 +1,30 @@
+"""Utilities for finding and focusing the TETR.IO window."""
+from __future__ import annotations
+
+from typing import Optional
+
+import pygetwindow as gw
+
+
+def find_tetrio_window() -> Optional[gw.Window]:
+    candidates = [window for window in gw.getAllWindows() if "tetr.io" in window.title.lower()]
+    if not candidates:
+        return None
+    # Prefer a visible, unminimised window
+    candidates.sort(key=lambda win: (not win.isActive, not win.isMaximized))
+    return candidates[0]
+
+
+def focus_tetrio_window() -> bool:
+    window = find_tetrio_window()
+    if not window:
+        return False
+    try:
+        window.activate()
+    except Exception:  # pragma: no cover - platform dependent
+        try:
+            window.minimize()
+            window.restore()
+        except Exception:
+            return False
+    return True

--- a/tetrio_bot/zetris_wrapper.py
+++ b/tetrio_bot/zetris_wrapper.py
@@ -1,0 +1,52 @@
+"""Wrapper around the Zetris AI inference API."""
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+import numpy as np
+
+
+@dataclass
+class ZetrisDecision:
+    actions: Sequence[str]
+
+
+class ZetrisAdapter:
+    """Thin wrapper that delegates to the Zetris AI implementation.
+
+    The adapter tries to import the official Zetris package. If it is not
+    available a descriptive error is raised.
+    """
+
+    def __init__(self, *, policy_path: str | None = None) -> None:
+        try:
+            self._module = importlib.import_module("zetris")
+        except ModuleNotFoundError as exc:  # pragma: no cover - depends on external package
+            raise RuntimeError(
+                "Le module 'zetris' est introuvable. Installez-le via 'pip install git+https://github.com/ZetrisAI/Zetris'."
+            ) from exc
+
+        # The public API exposes a `load_policy` helper which returns an agent
+        # capable of producing move sequences for a given board state. We import
+        # the helper lazily to avoid importing heavy dependencies when this
+        # module is only used for type checking.
+        try:
+            load_policy = getattr(self._module, "load_policy")
+        except AttributeError as exc:
+            raise RuntimeError(
+                "La bibliothèque Zetris ne fournit pas la fonction 'load_policy'. Vérifiez la version installée."
+            ) from exc
+
+        self._policy = load_policy(policy_path)
+
+    def decide(self, board: np.ndarray, queue: Iterable[str], hold: str | None = None) -> ZetrisDecision:
+        # Delegates to the model; the expected API is `policy.plan(board, queue, hold)`
+        try:
+            actions: List[str] = list(self._policy.plan(board=board, queue=list(queue), hold=hold))
+        except AttributeError as exc:  # pragma: no cover - depends on third-party implementation
+            raise RuntimeError(
+                "L'objet de politique Zetris ne possède pas la méthode 'plan'. Vérifiez la version installée."
+            ) from exc
+        return ZetrisDecision(actions=actions)


### PR DESCRIPTION
## Summary
- add a Python package that calibrates the board area, focuses the TETR.IO window, captures frames and forwards them to the Zetris AI
- expose a Tkinter GUI with calibration and start/stop controls plus a CLI launcher script
- document installation, calibration workflow, configuration and troubleshooting tips

## Testing
- python -m compileall tetrio_bot scripts

------
https://chatgpt.com/codex/tasks/task_e_68dd2cd0ec38832c9391aa8e00c46c85