### PR TITLE
Add pluggable decision engine support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ Avant la première utilisation, effectuez la calibration pour apprendre au bot o
 3. Cliquez sur **▶️ Lancer**. Le bot active automatiquement la fenêtre TETR.IO, capture l'écran, reconstruit la grille puis demande à Zetris le meilleur coup à jouer.
 4. Cliquez sur **⏹️ Arrêter** pour reprendre la main.
 
+### Utiliser un moteur d'IA tiers
+
+Le bot supporte désormais plusieurs moteurs de décision. Par défaut il s'appuie sur Zetris, mais vous pouvez brancher un moteur externe (par exemple celui du dépôt [UndoneMajor/tetrio-bot](https://github.com/UndoneMajor/tetrio-bot)) tant qu'il expose une fabrique retournant un objet ou une fonction capable de fournir des actions.
+
+```bash
+python scripts/run_bot.py --engine "mon_module:create_bot"
+```
+
+Le point d'entrée `module:fabrique` doit retourner soit:
+
+- un objet possédant une méthode `decide(board, queue, hold=None)` ou `plan(...)` qui renvoie la liste des actions ;
+- une fonction directement appelable avec les mêmes paramètres.
+
+Dans le cas du dépôt externe, exposez simplement une fabrique (par exemple `create_bot`) puis indiquez son chemin en argument `--engine`. Le paramètre `--policy` reste disponible si le moteur a besoin d'un chemin vers un modèle.
+
 ## Personnalisation
 
 - Le fichier de configuration permet d'ajuster les touches envoyées (`keymap`) ainsi que la cadence (`tick_rate`).

--- a/scripts/run_bot.py
+++ b/scripts/run_bot.py
@@ -9,9 +9,18 @@ from tetrio_bot.gui import BotGUI
 def main() -> None:
     parser = argparse.ArgumentParser(description="TETR.IO auto-player powered by Zetris")
     parser.add_argument("--policy", help="Chemin vers le modèle Zetris (optionnel)", default=None)
+    parser.add_argument(
+        "--engine",
+        default="zetris",
+        help=(
+            "Moteur de décision à utiliser. Par défaut 'zetris'. "
+            "Vous pouvez fournir un point d'entrée 'module:fabrique' pour un moteur tiers, par exemple "
+            "'mon_bot.adapter:factory'."
+        ),
+    )
     args = parser.parse_args()
 
-    gui = BotGUI(policy_path=args.policy)
+    gui = BotGUI(policy_path=args.policy, engine=args.engine)
     gui.run()
 
 

--- a/tetrio_bot/decision.py
+++ b/tetrio_bot/decision.py
@@ -1,0 +1,16 @@
+"""Common decision data structures for bot engines."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+
+@dataclass
+class Decision:
+    """Represents an ordered list of actions to execute."""
+
+    actions: Sequence[str]
+
+
+__all__ = ["Decision"]
+

--- a/tetrio_bot/engines.py
+++ b/tetrio_bot/engines.py
@@ -1,0 +1,116 @@
+"""Abstractions for decision engines used by the bot."""
+from __future__ import annotations
+
+import importlib
+import inspect
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Protocol, Sequence
+
+import numpy as np
+
+from .decision import Decision
+from .zetris_wrapper import ZetrisAdapter
+
+
+class DecisionProvider(Protocol):
+    """Protocol implemented by decision engines."""
+
+    def decide(self, board: np.ndarray, queue: Iterable[str], hold: str | None = None) -> Decision:
+        ...
+
+
+@dataclass
+class _CallableProvider:
+    """Wrap a callable so it behaves like a decision provider."""
+
+    func: Callable[[np.ndarray, Iterable[str], str | None], Any]
+
+    def decide(self, board: np.ndarray, queue: Iterable[str], hold: str | None = None) -> Decision:
+        result = self.func(board, queue, hold)
+        return _normalise_result(result)
+
+
+def _normalise_result(result: Any) -> Decision:
+    if isinstance(result, Decision):
+        return result
+    if isinstance(result, (str, bytes)):
+        raise TypeError("Une chaîne isolée ne peut pas représenter une séquence d'actions.")
+
+    if isinstance(result, Sequence) and all(isinstance(item, str) for item in result):
+        return Decision(actions=list(result))
+    if hasattr(result, "actions"):
+        actions = getattr(result, "actions")
+        if isinstance(actions, Sequence):
+            return Decision(actions=list(actions))
+    raise TypeError(
+        "Le moteur externe doit retourner soit un objet Decision, soit une séquence de chaînes représentant les actions."
+    )
+
+
+def _wrap_object(obj: Any) -> DecisionProvider:
+    if callable(obj):
+        return _CallableProvider(obj)
+
+    if hasattr(obj, "decide") and callable(obj.decide):
+        return _CallableProvider(obj.decide)
+
+    if hasattr(obj, "plan") and callable(obj.plan):
+        return _CallableProvider(obj.plan)
+
+    raise TypeError(
+        "L'entrée du moteur externe doit être un appelable ou exposer une méthode 'decide'/'plan'."
+    )
+
+
+def _invoke_factory(factory: Callable[..., Any], policy_path: str | None) -> Any:
+    try:
+        signature = inspect.signature(factory)
+    except (TypeError, ValueError):
+        return factory(policy_path=policy_path)
+
+    parameters = list(signature.parameters.values())
+    accepts_kwargs = any(param.kind == param.VAR_KEYWORD for param in parameters)
+    has_named_argument = any(param.name == "policy_path" for param in parameters)
+
+    if accepts_kwargs or has_named_argument:
+        return factory(policy_path=policy_path)
+
+    if policy_path is not None:
+        try:
+            return factory(policy_path)
+        except TypeError:
+            pass
+
+    return factory()
+
+
+def create_decision_provider(engine: str, *, policy_path: str | None = None) -> DecisionProvider:
+    """Create the decision provider corresponding to *engine*.
+
+    The default engine ``"zetris"`` utilise le modèle Zetris officiel. Pour
+    utiliser un moteur personnalisé, fournissez un chemin de type
+    ``"package.module:factory"``. La fabrique peut être soit une fonction qui
+    retourne un objet compatible, soit une classe instanciable.
+    """
+
+    if engine == "zetris":
+        return ZetrisAdapter(policy_path=policy_path)
+
+    module_name, sep, attr = engine.partition(":")
+    if not sep:
+        raise ValueError(
+            "Moteur inconnu. Utilisez 'zetris' ou un point d'entrée de type 'package.module:fabrique'."
+        )
+
+    module = importlib.import_module(module_name)
+    try:
+        factory = getattr(module, attr)
+    except AttributeError as exc:
+        raise RuntimeError(f"Le module '{module_name}' ne fournit pas l'attribut '{attr}'.") from exc
+
+    obj = _invoke_factory(factory, policy_path) if callable(factory) else factory
+    return _wrap_object(obj)
+
+
+__all__ = ["DecisionProvider", "create_decision_provider"]
+

--- a/tetrio_bot/gui.py
+++ b/tetrio_bot/gui.py
@@ -11,10 +11,11 @@ from .runner import BotRunner
 
 
 class BotGUI:
-    def __init__(self, *, policy_path: str | None = None):
+    def __init__(self, *, policy_path: str | None = None, engine: str = "zetris"):
         self._settings = load_settings()
         self._policy_path = policy_path
-        self._runner = BotRunner(self._settings, policy_path=policy_path)
+        self._engine = engine
+        self._runner = BotRunner(self._settings, policy_path=policy_path, engine=engine)
         self._running = False
 
         self._root = tk.Tk()
@@ -61,7 +62,11 @@ class BotGUI:
             try:
                 calibrate(self._settings, status_callback=self._status_var.set)
                 save_settings(self._settings)
-                self._runner = BotRunner(self._settings, policy_path=self._policy_path)
+                self._runner = BotRunner(
+                    self._settings,
+                    policy_path=self._policy_path,
+                    engine=self._engine,
+                )
             except Exception as exc:  # pragma: no cover - manual workflow
                 messagebox.showerror("Erreur", str(exc))
 

--- a/tetrio_bot/runner.py
+++ b/tetrio_bot/runner.py
@@ -9,15 +9,16 @@ import numpy as np
 
 from .capture import BoardCapture, PreviewCapture
 from .config import Settings
+from .engines import create_decision_provider
 from .controller import InputController
 from .window import focus_tetrio_window
-from .zetris_wrapper import ZetrisAdapter
 
 
 class BotRunner:
-    def __init__(self, settings: Settings, *, policy_path: str | None = None):
+    def __init__(self, settings: Settings, *, policy_path: str | None = None, engine: str = "zetris"):
         self._settings = settings
         self._policy_path = policy_path
+        self._engine = engine
         self._thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
 
@@ -40,11 +41,11 @@ class BotRunner:
         board_capture = BoardCapture(self._settings.board_region)
         preview_capture = PreviewCapture(self._settings.preview_region)
         controller = InputController(self._settings.keymap)
-        zetris = ZetrisAdapter(policy_path=self._policy_path)
+        decision_provider = create_decision_provider(self._engine, policy_path=self._policy_path)
 
         while not self._stop_event.is_set():
             board_state = board_capture.capture_board()
             queue = preview_capture.capture_queue(max_pieces=5)
-            decision = zetris.decide(board_state.grid.astype(np.float32), queue, hold=None)
+            decision = decision_provider.decide(board_state.grid.astype(np.float32), queue, hold=None)
             controller.execute_actions(decision.actions)
             time.sleep(self._settings.tick_rate)

--- a/tetrio_bot/zetris_wrapper.py
+++ b/tetrio_bot/zetris_wrapper.py
@@ -2,15 +2,11 @@
 from __future__ import annotations
 
 import importlib
-from dataclasses import dataclass
-from typing import Iterable, List, Sequence
+from typing import Iterable, List
 
 import numpy as np
 
-
-@dataclass
-class ZetrisDecision:
-    actions: Sequence[str]
+from .decision import Decision
 
 
 class ZetrisAdapter:
@@ -41,7 +37,7 @@ class ZetrisAdapter:
 
         self._policy = load_policy(policy_path)
 
-    def decide(self, board: np.ndarray, queue: Iterable[str], hold: str | None = None) -> ZetrisDecision:
+    def decide(self, board: np.ndarray, queue: Iterable[str], hold: str | None = None) -> Decision:
         # Delegates to the model; the expected API is `policy.plan(board, queue, hold)`
         try:
             actions: List[str] = list(self._policy.plan(board=board, queue=list(queue), hold=hold))
@@ -49,4 +45,4 @@ class ZetrisAdapter:
             raise RuntimeError(
                 "L'objet de politique Zetris ne possède pas la méthode 'plan'. Vérifiez la version installée."
             ) from exc
-        return ZetrisDecision(actions=actions)
+        return Decision(actions=actions)


### PR DESCRIPTION
## Summary
- add a pluggable decision engine layer so the bot can use Zetris or an external provider
- expose the engine selection through the CLI/GUI and document how to hook third-party bots
- normalize decision data handling for built-in and external engines

## Testing
- python -m compileall scripts tetrio_bot

------
https://chatgpt.com/codex/tasks/task_e_68dd35451884832c979bd70267cb6036